### PR TITLE
Fixed xtea auto-patch not saving correctly

### DIFF
--- a/src/pages/tools/online/xtea.js
+++ b/src/pages/tools/online/xtea.js
@@ -232,6 +232,7 @@ export default function Xtea() {
             /patchlevel=\d+\n/gi,
             "patchlevel=310\n"
         )
+        setTextValue(target.value)
     }
 
     return (


### PR DESCRIPTION
When you auto-patch is will update the content in the DOM, but not in memory. This causes the save button to fail when saving. This PR fixes that issue.